### PR TITLE
Init locals whenever a new variable is added

### DIFF
--- a/Aspekt.Bootstrap/Bootstrap.cs
+++ b/Aspekt.Bootstrap/Bootstrap.cs
@@ -34,7 +34,7 @@ namespace Aspekt.Bootstrap
                      var fi = meth.Body.Instructions.First();
                      InstructionHelper ih;
 
-                     // This is really hacky. This is used to signal whether it's our first aspect, or 
+                     // This is really hacky. This is used to signal whether it's our first aspect, or
                      // the next one.
                      if (target.StartInstruction == null)
                          ih = new InstructionHelper(module, il, fi, InstructionHelper.Insert.Before);
@@ -57,7 +57,7 @@ namespace Aspekt.Bootstrap
 
                      target.StartInstruction = ih.LastInstruction; // so that we will create the next aspects AFTER
 
-                     // walk the instructions looking for returns, based on what teh function is returning 
+                     // walk the instructions looking for returns, based on what teh function is returning
                      // is where we inject the OnExit instructions.
                      // so how do I tell what the function returns?
                      if (MethodTraits.HasMethod(attr.AttributeType.Resolve(), nameof(Aspect.OnExit), typeof(MethodArguments)))
@@ -68,10 +68,10 @@ namespace Aspekt.Bootstrap
                      {
                          if (target.ExceptionHandler == null)
                          {
-                             var exception = new VariableDefinition(meth.Module.ImportReference(typeof(Exception)));
-                             meth.Body.Variables.Add(exception);
-
                              var c = new InstructionHelper(module, il, meth.Body.Instructions.Last());
+
+                             var exception = c.NewVariable(typeof(Exception));
+
                              c.Next(il.Create(OpCodes.Stloc_S, exception))
                                 .Next(OpCodes.Ldloc, attrVar)
                                 .Next(OpCodes.Ldloc, target.MethodArguments)
@@ -123,10 +123,10 @@ namespace Aspekt.Bootstrap
                 {
                     wp.WriteSymbols = true;
                 }
-                
+
                 assembly.Write(wp);
             }
-           
+
         }
     }
 

--- a/Aspekt.Bootstrap/IlGenerator.cs
+++ b/Aspekt.Bootstrap/IlGenerator.cs
@@ -17,9 +17,7 @@ namespace Aspekt.Bootstrap
                 return null;
 
             // first we need something to store the parameters in
-            var argList = new VariableDefinition(md.Module.ImportReference(typeof(Arguments)));
-            md.Body.Variables.Add(argList);
-
+            var argList = ic.NewVariable(typeof(Arguments));
 
             ic.Next(OpCodes.Ldc_I4, md.Parameters.Count);
             ic.NewObj<Arguments>(typeof(Int32)); // this will create the object we want on the stack
@@ -170,8 +168,8 @@ namespace Aspekt.Bootstrap
                     ih.Next(OpCodes.Ldloc, methArgs);
                     ih.CallVirt<Aspect>(nameof(Aspect.OnExit), typeof(MethodArguments));
 
-                    // This is kind of dumb. I need to store the return instruction, and the first instruction to 
-                    // what I added. So that I can go through later, and find instructions that branch to 
+                    // This is kind of dumb. I need to store the return instruction, and the first instruction to
+                    // what I added. So that I can go through later, and find instructions that branch to
                     // the old instruction, and replace that with instruction to branch
                     // to this new instruction.
                     returnInst.Add(new Tuple<Instruction, Instruction>(rep, ih.FirstInstruction));
@@ -231,6 +229,6 @@ namespace Aspekt.Bootstrap
             return attrVar;
         }
 
-        
+
     }
 }

--- a/Aspekt.Bootstrap/InstructionHelper.cs
+++ b/Aspekt.Bootstrap/InstructionHelper.cs
@@ -53,6 +53,10 @@ namespace Aspekt.Bootstrap
         {
             var vd = new VariableDefinition(tr);
             il_.Body.Variables.Add(vd);
+
+            // Ensure that the method is initializing locals
+            il_.Body.InitLocals = true;
+
             return vd;
         }
 
@@ -93,7 +97,7 @@ namespace Aspekt.Bootstrap
             var mth = typeof(T).GetMethod(callName, args);
             return Next(OpCodes.Callvirt, module_.ImportReference(mth));
         }
-         
+
         public InstructionHelper CallVirt(TypeReference tr, String methodName, params Type[] args)
         {
             var t = Type.GetType(tr.FullName + ", " + tr.Module.Assembly.FullName);
@@ -116,7 +120,7 @@ namespace Aspekt.Bootstrap
             return this;
         }
 
-    
+
         public InstructionHelper Next(OpCode op, long i)
         {
             return Next(il_.Create(op, i));


### PR DESCRIPTION
Motivation
----------
Generated IL cannot be verified unless locals are initialized to zero.
This flag will be false for any method which has no locals, so we should
set it to true if we add local variables.

Modifications
-------------
Use InstructionHelper.NewVariable when adding new variables to provide
consistent behavior.

Set InitLocals to true whenever InstructionHelper.NewVariable is used.