### PR TITLE
Add .NET Standard 2.0 support to libraries

### DIFF
--- a/Aspekt.Contracts/Aspekt.Contracts.csproj
+++ b/Aspekt.Contracts/Aspekt.Contracts.csproj
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
-    
+    <TargetFrameworks>net452;net461;netstandard2.0</TargetFrameworks>
+
     <Title>Aspekt AOP Contracts</Title>
     <Authors>mvpete</Authors>
     <Description>Aspekt Contract built on the lightweight AOP foundation Aspekt to allow for code contracts</Description>

--- a/Aspekt.Logging.Test/Aspekt.Logging.Test.csproj
+++ b/Aspekt.Logging.Test/Aspekt.Logging.Test.csproj
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;net461</TargetFrameworks>
 
     <Copyright>Peter Lorimer  © 2018</Copyright>
   </PropertyGroup>

--- a/Aspekt.Logging/Aspekt.Logging.csproj
+++ b/Aspekt.Logging/Aspekt.Logging.csproj
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;net461;netstandard2.0</TargetFrameworks>
 
     <Title>Aspekt AOP Logging</Title>
     <Authors>mvpete</Authors>

--- a/Aspekt.Test/Aspekt.Test.csproj
+++ b/Aspekt.Test/Aspekt.Test.csproj
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;net461</TargetFrameworks>
 
     <Copyright>Peter Lorimer  © 2018</Copyright>
   </PropertyGroup>

--- a/Aspekt/Aspekt.csproj
+++ b/Aspekt/Aspekt.csproj
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;net461;netstandard2.0</TargetFrameworks>
 
     <Title>Aspekt AOP</Title>
     <Authors>mvpete</Authors>


### PR DESCRIPTION
Motivation
----------
Move towards support for .NET Core by allowing the libraries to be
referenced using .NET Standard 2.0.

Modifications
-------------
Add targets for .NET 4.6.1 and .NET Standard 2.0 to the libraries
(There are some issues with .NET Standard 2.0 support until .NET 4.7.2
which can be simplified by having a 4.6.1 target).

Add .NET 4.6.1 target to unit tests.