### PR TITLE
[WIP] Correct try/catch leave behavior

### DIFF
--- a/Aspekt.Bootstrap/IlGenerator.cs
+++ b/Aspekt.Bootstrap/IlGenerator.cs
@@ -3,14 +3,19 @@ using Mono.Cecil.Cil;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace Aspekt.Bootstrap
 {
     /// <summary>
     /// A static helper class for capturing and writing appropriate IL instructions
     /// </summary>
-    static class IlGenerator
+    internal static class IlGenerator
     {
+        private static readonly MethodBase OnExitMethod = typeof(Aspect).GetMethod(
+            nameof(Aspect.OnExit),
+            new [] {typeof(MethodArguments)});
+
         public static VariableDefinition CaptureMethodArguments(InstructionHelper ic, MethodDefinition md)
         {
             if (md.Parameters.Count == 0)
@@ -22,7 +27,7 @@ namespace Aspekt.Bootstrap
             var argList = ic.NewVariable(typeof(Arguments));
 
             ic.Next(OpCodes.Ldc_I4, md.Parameters.Count);
-            ic.NewObj<Arguments>(typeof(Int32)); // this will create the object we want on the stack
+            ic.NewObj<Arguments>(typeof(int)); // this will create the object we want on the stack
             ic.Next(OpCodes.Stloc, argList);
 
 
@@ -54,7 +59,7 @@ namespace Aspekt.Bootstrap
             return argList;
         }
 
-        public static String GenerateMethodNameFormat(MethodDefinition md)
+        public static string GenerateMethodNameFormat(MethodDefinition md)
         {
             var name = md.FullName;
             int i = 0;
@@ -89,7 +94,7 @@ namespace Aspekt.Bootstrap
                 ic.Next(OpCodes.Ldarg_0);
             }
 
-            ic.NewObj<MethodArguments>(typeof(String), typeof(String), typeof(String), typeof(Arguments), typeof(object));
+            ic.NewObj<MethodArguments>(typeof(string), typeof(string), typeof(string), typeof(Arguments), typeof(object));
             ic.Next(OpCodes.Stloc, methArgs);
             return methArgs;
         }
@@ -164,50 +169,109 @@ namespace Aspekt.Bootstrap
 
         public static void InsertOnExitCalls(ILProcessor il, ModuleDefinition module, MethodDefinition md, VariableDefinition attrVar, VariableDefinition methArgs)
         {
-
-            var returnInst = new List<Tuple<Instruction, Instruction>>();
             // adjust all the return instructions
-            for (int i = 0; i < md.Body.Instructions.Count; ++i)
+            for (var i = 0; i < md.Body.Instructions.Count; ++i)
             {
-                Instruction inst = md.Body.Instructions[i];
+                var inst = md.Body.Instructions[i];
                 // Find each return code, and add our three instructions.
                 if (inst.OpCode == OpCodes.Ret)
                 {
-                    Instruction rep = inst;
+                    var rep = inst;
                     if (md.ReturnType.FullName != typeof(void).FullName)
+                    {
                         rep = inst.Previous; // get the previous instruction, because this SHOULD be the retval
+                    }
 
-
-                    var ih = new InstructionHelper(module, il, rep, InstructionHelper.Insert.Before);
-                    ih.Next(OpCodes.Ldloc, attrVar);
-                    ih.Next(OpCodes.Ldloc, methArgs);
-                    ih.CallVirt<Aspect>(nameof(Aspect.OnExit), typeof(MethodArguments));
-
-                    // This is kind of dumb. I need to store the return instruction, and the first instruction to
-                    // what I added. So that I can go through later, and find instructions that branch to
-                    // the old instruction, and replace that with instruction to branch
-                    // to this new instruction.
-                    returnInst.Add(new Tuple<Instruction, Instruction>(rep, ih.FirstInstruction));
+                    // Replace it with three new instructions, plus itself. We use ReplaceInstructionAndLeaveTarget
+                    // to reuse the logic to adjust all the branch and exception handling adjustments.
+                    // This would be low performance (during bootstrap phase) if there are lots of Ret instructions,
+                    // but generally there is only one Ret per method.
+                    ReplaceInstructionAndLeaveTarget(
+                        il,
+                        md,
+                        rep,
+                        il.Create(OpCodes.Ldloc, attrVar),
+                        il.Create(OpCodes.Ldloc, methArgs),
+                        il.Create(OpCodes.Callvirt, md.Module.ImportReference(OnExitMethod)));
 
                     i = i + 3;  // We just added 3 instructions
                 }
+            }
+        }
 
+        /// <summary>
+        /// Replace an instruction with a new set of instructions, redirecting all branches to
+        /// the new instruction and adjusting exception handlers.
+        /// </summary>
+        /// <param name="il"><see cref="ILProcessor"/> to use.</param>
+        /// <param name="method"><see cref="MethodDefinition"/> where the replacement is taking place.</param>
+        /// <param name="targetInstruction">Instruction to be replaced.</param>
+        /// <param name="instructions">New instructions to insert.</param>
+        public static void ReplaceInstruction(ILProcessor il, MethodDefinition method,
+            Instruction targetInstruction, params Instruction[] instructions)
+        {
+            ReplaceInstructionAndLeaveTarget(il, method, targetInstruction, instructions);
+
+            il.Remove(targetInstruction);
+        }
+
+        /// <summary>
+        /// Replace an instruction with a new set of instructions, redirecting all branches to
+        /// the new instruction and adjusting exception handlers. The target instruction, however,
+        /// is left in place after the new instructions.
+        /// </summary>
+        /// <param name="il"><see cref="ILProcessor"/> to use.</param>
+        /// <param name="method"><see cref="MethodDefinition"/> where the replacement is taking place.</param>
+        /// <param name="targetInstruction">Instruction where the new instructions are inserted.</param>
+        /// <param name="instructions">New instructions to insert.</param>
+        public static void ReplaceInstructionAndLeaveTarget(ILProcessor il, MethodDefinition method,
+            Instruction targetInstruction, params Instruction[] instructions)
+        {
+            var ih = new InstructionHelper(method.Module, il, targetInstruction, InstructionHelper.Insert.Before);
+            for (var i = 0; i < instructions.Length; ++i)
+            {
+                ih.Next(instructions[i]);
             }
 
             // go through and replace the branch instructions.
-            for (int i = 0; i < md.Body.Instructions.Count; ++i)
+            for (var i = 0; i < method.Body.Instructions.Count; ++i)
             {
-                Instruction inst = md.Body.Instructions[i];
-                var jp = returnInst.SingleOrDefault(t => t.Item1 == inst.Operand);
-                if (IsBranchInstruction(inst.OpCode) && jp!=null)
+                var inst = method.Body.Instructions[i];
+                if (IsBranchInstruction(inst.OpCode) && inst.Operand == targetInstruction)
                 {
-                    // create a new branch op to the instruction that I put before.
-                    var brto = md.Body.GetILProcessor().Create(inst.OpCode, jp.Item2);
-                    md.Body.GetILProcessor().InsertBefore(inst, brto);
-                    md.Body.GetILProcessor().Remove(inst); // remove the existing branch.
+                    ReplaceInstruction(
+                        il,
+                        method,
+                        inst,
+                        il.Create(inst.OpCode, ih.FirstInstruction));
                 }
             }
 
+            // go through and replace exception handler ends
+            for (var i = 0; i < method.Body.ExceptionHandlers.Count; ++i)
+            {
+                var handler = method.Body.ExceptionHandlers[i];
+
+                if (targetInstruction == handler.TryStart)
+                {
+                    handler.TryStart = ih.FirstInstruction;
+                }
+
+                if (targetInstruction == handler.TryEnd)
+                {
+                    handler.TryEnd = ih.FirstInstruction;
+                }
+
+                if (targetInstruction == handler.HandlerEnd)
+                {
+                    handler.HandlerEnd = ih.FirstInstruction;
+                }
+
+                if (targetInstruction == handler.HandlerStart)
+                {
+                    handler.HandlerStart = ih.FirstInstruction;
+                }
+            }
         }
 
         private static bool IsBranchInstruction(OpCode code)
@@ -217,7 +281,9 @@ namespace Aspekt.Bootstrap
                    code == OpCodes.Brfalse ||
                    code == OpCodes.Brfalse_S ||
                    code == OpCodes.Brtrue ||
-                   code == OpCodes.Brtrue_S;
+                   code == OpCodes.Brtrue_S ||
+                   code == OpCodes.Leave ||
+                   code == OpCodes.Leave_S;
         }
 
         public static void InsertOnEntryCalls(InstructionHelper ih, VariableDefinition attrVar, VariableDefinition methArgs)


### PR DESCRIPTION
Motivation
----------
When adding a try/catch block, the current approach of leaving ret
operations within the try block is semantically incorrect for MSIL.

Modifications
-------------
Rework the try/catch block to rewrite the ret instructions as leave
instructions, adding a new ret at the end of the method outside the
try/catch block. Save the return value, if any, and reload outside the
try/catch.

Move the call to InsertOnExitCalls after the OnException handling so
that it only inserts calls before the new, final ret instruction.

Add ReplaceInstruction and ReplaceInstructionAndLeaveTarget helpers to
IlGenerator, and rework InsertOnExitCalls to also use these helpers.
This manages the replacement of branch statements recursively, and also
adjusts exception blocks.