### PR TITLE
Run .NET Core flavor bootstrapper

### DIFF
--- a/Aspekt.Bootstrap.Host/Aspekt.Bootstrap.Host.csproj
+++ b/Aspekt.Bootstrap.Host/Aspekt.Bootstrap.Host.csproj
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <OutputType>WinExe</OutputType>
 

--- a/Aspekt.Bootstrap.UnitTests/Aspekt.Bootstrap.UnitTests.csproj
+++ b/Aspekt.Bootstrap.UnitTests/Aspekt.Bootstrap.UnitTests.csproj
@@ -1,13 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;net461</TargetFrameworks>
+    <TargetFrameworks>net452;net461;netcoreapp2.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Mono.Cecil" Version="0.10.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/Aspekt.Logging.Test/Aspekt.Logging.Test.csproj
+++ b/Aspekt.Logging.Test/Aspekt.Logging.Test.csproj
@@ -1,14 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;net461</TargetFrameworks>
+    <TargetFrameworks>net452;net461;netcoreapp2.0</TargetFrameworks>
 
     <Copyright>Peter Lorimer  © 2018</Copyright>
   </PropertyGroup>
 
   <Target Name="Bootstrap" AfterTargets="Build" Condition=" '$(TargetFramework)' != '' ">
     <Exec Command="&quot;$(MSBuildThisFileDirectory)../Aspekt.Bootstrap.Host/bin/$(Configuration)/net452/Aspekt.Bootstrap.Host.exe&quot; &quot;$(AssemblyName).dll&quot;"
-          WorkingDirectory="$(OutputPath)" />
+          WorkingDirectory="$(OutputPath)"
+          Condition=" '$(TargetFramework)' != 'netcoreapp2.0' "/>
+
+    <Exec Command="dotnet &quot;$(MSBuildThisFileDirectory)../Aspekt.Bootstrap.Host/bin/$(Configuration)/netcoreapp2.0/Aspekt.Bootstrap.Host.dll&quot; &quot;$(AssemblyName).dll&quot;"
+          WorkingDirectory="$(OutputPath)"
+          Condition=" '$(TargetFramework)' == 'netcoreapp2.0' " />
   </Target>
 
   <ItemGroup>

--- a/Aspekt.Test/Aspekt.Test.csproj
+++ b/Aspekt.Test/Aspekt.Test.csproj
@@ -1,14 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;net461</TargetFrameworks>
+    <TargetFrameworks>net452;net461;netcoreapp2.0</TargetFrameworks>
 
     <Copyright>Peter Lorimer  © 2018</Copyright>
   </PropertyGroup>
 
   <Target Name="Bootstrap" AfterTargets="Build" Condition=" '$(TargetFramework)' != '' ">
     <Exec Command="&quot;$(MSBuildThisFileDirectory)../Aspekt.Bootstrap.Host/bin/$(Configuration)/net452/Aspekt.Bootstrap.Host.exe&quot; &quot;$(AssemblyName).dll&quot;"
-          WorkingDirectory="$(OutputPath)" />
+          WorkingDirectory="$(OutputPath)"
+          Condition=" '$(TargetFramework)' != 'netcoreapp2.0' " />
+
+    <Exec Command="dotnet &quot;$(MSBuildThisFileDirectory)../Aspekt.Bootstrap.Host/bin/$(Configuration)/netcoreapp2.0/Aspekt.Bootstrap.Host.dll&quot; &quot;$(AssemblyName).dll&quot;"
+          WorkingDirectory="$(OutputPath)"
+          Condition=" '$(TargetFramework)' == 'netcoreapp2.0' " />
   </Target>
 
   <ItemGroup>


### PR DESCRIPTION
Motivation
----------
Confirm that our current bootstrapper will work if run in a .NET Core
environment.

Modifications
-------------
Execute tests in .NET Core, including running the .NET Core build of
the bootstrapper.

Results
-------
We can now confirm that the bootstrapper works in .NET Core. However,
targets have not yet been updated to automatically bootstrap correctly
for consumers installing the Aspekt package. This improvement will come
in a future iteration.