### PR TITLE
Implement bootstrap as MSBuild task

### DIFF
--- a/Aspekt.Bootstrap.Host/Program.cs
+++ b/Aspekt.Bootstrap.Host/Program.cs
@@ -1,10 +1,12 @@
+using System;
+
 namespace Aspekt.Bootstrap.Host
 {
     public class Program
     {
         public static void Main(string[] args)
         {
-            Bootstrap.Apply(args[0]);
+            Bootstrap.Apply(args[0], new ReferencedAssembly[] {});
         }
     }
 }

--- a/Aspekt.Bootstrap.Tasks/Aspekt.Bootstrap.Tasks.csproj
+++ b/Aspekt.Bootstrap.Tasks/Aspekt.Bootstrap.Tasks.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net46</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.1.1012" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.1012" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Aspekt.Bootstrap\Aspekt.Bootstrap.csproj" />
+    <ProjectReference Include="..\Aspekt\Aspekt.csproj" />
+  </ItemGroup>
+</Project>

--- a/Aspekt.Bootstrap.Tasks/AspektBootstrap.cs
+++ b/Aspekt.Bootstrap.Tasks/AspektBootstrap.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Linq;
+using Microsoft.Build.Framework;
+
+namespace Aspekt.Bootstrap.Tasks
+{
+    public class AspektBootstrap : Microsoft.Build.Utilities.Task
+    {
+        [Required]
+        public ITaskItem[] Assemblies { get; set; }
+
+        [Required]
+        public ITaskItem[] References { get; set; }
+
+        public override bool Execute()
+        {
+            var success = true;
+
+            foreach (var item in Assemblies)
+            {
+                var assemblyPath = item.GetMetadata("FullPath");
+
+                try
+                {
+                    Log.LogMessage(MessageImportance.Low, "Aspekt bootstrapping \"{0}\"", assemblyPath);
+
+                    Bootstrap.Apply(assemblyPath,
+                        References
+                            .Select(p => new ReferencedAssembly
+                            {
+                                FilePath = p.ItemSpec,
+                                FullName = p.GetMetadata("FusionName")
+                            }));
+
+                    Log.LogMessage(MessageImportance.High, "Aspekt bootstrapped \"{0}\"", assemblyPath);
+                }
+                catch (Exception ex)
+                {
+                    #if DEBUG
+                    var showStackTrace = true;
+                    #else
+                    var showStackTrace = false;
+                    #endif
+
+                    // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+                    Log.LogErrorFromException(ex, showStackTrace, true, assemblyPath);
+                    success = false;
+                }
+            }
+
+            return success;
+        }
+    }
+}

--- a/Aspekt.Bootstrap/PreregisteredAssemblyResolver.cs
+++ b/Aspekt.Bootstrap/PreregisteredAssemblyResolver.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using Mono.Cecil;
+
+namespace Aspekt.Bootstrap
+{
+    public class PreregisteredAssemblyResolver : DefaultAssemblyResolver
+    {
+        private readonly Dictionary<string, string> preregistered_ = new Dictionary<string, string>();
+
+        protected override AssemblyDefinition SearchDirectory(AssemblyNameReference name, IEnumerable<string> directories, ReaderParameters parameters)
+        {
+            if (preregistered_.TryGetValue(name.Name, out var filePath))
+            {
+                if (parameters.AssemblyResolver == null)
+                {
+                    parameters.AssemblyResolver = this;
+                }
+
+                var module = ModuleDefinition.ReadModule(filePath, parameters);
+
+                return module.Assembly;
+            }
+
+            return base.SearchDirectory(name, directories, parameters);
+        }
+
+        public void PreregisterAssembly(ReferencedAssembly referencedAssembly)
+        {
+            if (string.IsNullOrEmpty(referencedAssembly.FullName))
+            {
+                return;
+            }
+
+            var simpleName = GetSimpleName(referencedAssembly.FullName);
+            if (!string.IsNullOrEmpty(simpleName) &&
+                !preregistered_.ContainsKey(simpleName))
+            {
+                preregistered_.Add(simpleName, referencedAssembly.FilePath);
+            }
+        }
+
+        private static string GetSimpleName(string fullName)
+        {
+            return fullName.Split(',')[0].Trim();
+        }
+    }
+}

--- a/Aspekt.Bootstrap/ReferencedAssembly.cs
+++ b/Aspekt.Bootstrap/ReferencedAssembly.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Aspekt.Bootstrap
+{
+    public class ReferencedAssembly
+    {
+        public string FullName { get; set; }
+        public string FilePath { get; set; }
+    }
+}

--- a/Aspekt.sln
+++ b/Aspekt.sln
@@ -25,9 +25,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aspekt.Contracts", "Aspekt.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aspekt.Logging.Test", "Aspekt.Logging.Test\Aspekt.Logging.Test.csproj", "{C4AACDE6-B8BE-4BC5-BB67-7917F02F0B6F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aspekt.Foundation.Test", "Aspekt.Foundation.Test\Aspekt.Foundation.Test.csproj", "{FD868722-056B-42BA-A7AB-7F3E2B61F827}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aspekt.Foundation.Test", "Aspekt.Foundation.Test\Aspekt.Foundation.Test.csproj", "{FD868722-056B-42BA-A7AB-7F3E2B61F827}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aspekt.Bootstrap.Test", "Aspekt.Bootstrap.Test\Aspekt.Bootstrap.Test.csproj", "{C42ADB9D-3748-43FA-911B-9207521ADD50}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aspekt.Bootstrap.Tasks", "Aspekt.Bootstrap.Tasks\Aspekt.Bootstrap.Tasks.csproj", "{E2A9BDBF-3C5F-48FE-B23E-4A99D3463240}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -75,6 +77,10 @@ Global
 		{C42ADB9D-3748-43FA-911B-9207521ADD50}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C42ADB9D-3748-43FA-911B-9207521ADD50}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C42ADB9D-3748-43FA-911B-9207521ADD50}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E2A9BDBF-3C5F-48FE-B23E-4A99D3463240}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E2A9BDBF-3C5F-48FE-B23E-4A99D3463240}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E2A9BDBF-3C5F-48FE-B23E-4A99D3463240}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E2A9BDBF-3C5F-48FE-B23E-4A99D3463240}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Aspekt/Aspekt.csproj
+++ b/Aspekt/Aspekt.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net452;net461;netstandard2.0</TargetFrameworks>
@@ -12,17 +12,21 @@
     <PackageTags>AOP;Aspect Oriented Programming</PackageTags>
     <RepositoryUrl>http://github.com/mvpete/aspekt</RepositoryUrl>
 
-    <BootstrapHostFolder>..\Aspekt.Bootstrap.Host\bin\$(Configuration)\net452\</BootstrapHostFolder>
+    <BootstrapTaskOutputFolder>..\Aspekt.Bootstrap.Tasks\bin\$(Configuration)\</BootstrapTaskOutputFolder>
+    <NoWarn>$(NoWarn);NU5100</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="*.targets" />
-    <Content Include="*.targets">
+    <None Remove="**\*.targets;**\*.props" />
+    <Content Include="build\*.targets;build\*.props">
       <PackagePath>build</PackagePath>
     </Content>
-    <Content Include="$(BootstrapHostFolder)*.exe;$(BootstrapHostFolder)*.dll">
-      <Link>tools\%(Filename)%(Extension)</Link>
-      <PackagePath>tools</PackagePath>
+    <Content Include="buildMultiTargeting\*.targets;buildMultiTargeting\*.props">
+      <PackagePath>buildMultiTargeting</PackagePath>
+    </Content>
+    <Content Include="$(BootstrapTaskOutputFolder)net46\*.dll" Visible="false">
+      <PackagePath>tasks\net46</PackagePath>
     </Content>
   </ItemGroup>
+
 </Project>

--- a/Aspekt/Aspekt.targets
+++ b/Aspekt/Aspekt.targets
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Target Name="AspektTarget" AfterTargets="Build">
-        <Message Importance="high" Text="Exec Command : $(MSBuildThisFileDirectory)..\tools\Aspekt.Bootstrap.Host.exe $(TargetPath)" />
-        <Exec  Command="$(MSBuildThisFileDirectory)..\tools\Aspekt.Bootstrap.Host.exe $(TargetPath)" WorkingDirectory="$(TargetDir)"/>
-        <Message Importance="high" Text="Fin" />
-    </Target>
-</Project>

--- a/Aspekt/build/Aspekt.props
+++ b/Aspekt/build/Aspekt.props
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ExecuteAspektBootstrap>true</ExecuteAspektBootstrap>
+
+    <AspektGatherAssembliesDependsOn>Compile</AspektGatherAssembliesDependsOn>
+    <AspektBootstrapDependsOn>AspektGatherAssemblies</AspektBootstrapDependsOn>
+  </PropertyGroup>
+</Project>

--- a/Aspekt/build/Aspekt.targets
+++ b/Aspekt/build/Aspekt.targets
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_AspektTaskAssembly Condition="'$(_AspektTaskAssembly)' == ''">$(MSBuildThisFileDirectory)..\tasks\net46\Aspekt.Bootstrap.Tasks.dll</_AspektTaskAssembly>
+  </PropertyGroup>
+
+  <UsingTask TaskName="Aspekt.Bootstrap.Tasks.AspektBootstrap"
+             AssemblyFile="$(_AspektTaskAssembly)" />
+
+  <Target Name="AspektGatherAssemblies"
+          DependsOnTargets="$(AspektGatherAssembliesDependsOn)"
+          Condition=" '$(ExecuteAspektBootstrap)' == 'true' And '$(IsCrossTargetingBuild)' != 'true' ">
+    <ItemGroup>
+      <AspektAssemblies Include="@(IntermediateAssembly)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="AspektBootstrap"
+          AfterTargets="Compile"
+          DependsOnTargets="$(AspektBootstrapDependsOn)"
+          Condition=" '$(ExecuteAspektBootstrap)' == 'true' And '$(IsCrossTargetingBuild)' != 'true' ">
+    <AspektBootstrap Assemblies="@(AspektAssemblies)"
+                     References="@(ReferencePathWithRefAssemblies)"/>
+  </Target>
+</Project>

--- a/Aspekt/buildMultiTargeting/Aspekt.props
+++ b/Aspekt/buildMultiTargeting/Aspekt.props
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildThisFileDirectory)..\build\Aspekt.props" />
+</Project>

--- a/Aspekt/buildMultiTargeting/Aspekt.targets
+++ b/Aspekt/buildMultiTargeting/Aspekt.targets
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildThisFileDirectory)..\build\Aspekt.targets" />
+</Project>


### PR DESCRIPTION
Motivation
----------
Improve performance by running bootstrap in-process and will make
implementing .NET Core builds (#18) easier.

Modifications
-------------
Add Aspekt.Bootstrap.Tasks assembly, and change Aspekt NuGet package
to use this task instead of Aspekt.Bootstrap.Host.

Add build property to allow consumers to disable automatic bootstrap,
as well as some points for build customization.

Update Bootstrap to accept a list of referenced assemblies, which are
resolved using PreregisteredAssemblyResolver. This supports bootstrap
in the obj folder instead of the bin folder, accepting the list of
assemblies located in other folders from MSBuild.

Results
--------
Consumers have the bootstrap performing in-process. Still only
works on MSBuild Full flavor, not the MSBuild Core flavor.

*Note:* Test assemblies are still using Aspekt.Bootstrap.Host due to
problems with file locks being held by MSBuild in Visual Studio.
